### PR TITLE
Regle le probleme de logout eternel

### DIFF
--- a/Google Chrome/background.js
+++ b/Google Chrome/background.js
@@ -347,6 +347,8 @@ Notificateur.prototype = {
 				chrome.browserAction.enable();
 				this.logged = false;
 			}
+			// on arrete le parsing
+			this.checkPending = false;
 			return;
 		} else {
 			if(!this.logged) {

--- a/Google Chrome/manifest.json
+++ b/Google Chrome/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "ZdS Notificateur",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "manifest_version": 2,
     "description": "Extensions pour Google Chrome pour connaitre le nombre de notifications ou MP de ZesteDeSavoir sans avoir besoin d'ouvrir le site",
     "offline_enabled": false,


### PR DESCRIPTION
Lorsqu'on est logout, le notificateur ne remet pas la variable checkPending a false.
Du coup on ne refait plus jamais de requête/parsage et le notificateur ne marche plus sans reset.
Ce fix remet a faux le booléen avant la sortie prématurée.