### PR TITLE
Refresh from the visited page

### DIFF
--- a/Firefox/manifest.json
+++ b/Firefox/manifest.json
@@ -22,6 +22,11 @@
     "page": "options/options.html"
   },
 
+  "content_scripts": [ {
+    "matches": ["*://zestedesavoir.com/*"],
+    "js": ["updateState.js"]
+  }],
+
   "background": {
     "scripts": ["notifier.js"]
   },

--- a/Firefox/notifier.js
+++ b/Firefox/notifier.js
@@ -198,3 +198,30 @@ function popupNotification (title, content) {
 // Update the popup
 setInterval(getNotificationsFromAPI, updateDelay)
 getNotificationsFromAPI()
+
+/**
+ * Compare current state with the one of the loading page
+ * @param  the content of the message request
+ */
+
+function updateState(request) {
+  const lastState = connected ? (notifCounter > 0 ? 2 : 1 ) : 0;
+
+  if( request.state !== lastState ) { // If any difference update the state
+    switch( request.state ) {
+      case 1:
+        chrome.browserAction.setIcon({path: 'icons/clem_48.png'})
+        break;
+      case 2:
+        chrome.browserAction.setIcon({path: 'icons/icone_n_20.png'})
+        break;
+      case 0:
+        chrome.browserAction.setIcon({path: 'icons/notconnected.png'})
+        break;
+    }
+    lastIcon = request.state;
+    getNotificationsFromAPI(); // Update the state
+  }
+}
+
+browser.runtime.onMessage.addListener(updateState);

--- a/Firefox/updateState.js
+++ b/Firefox/updateState.js
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+const debugMode = false
+
+const XPATH_to_test_connection = "count(//div[contains(concat(' ',normalize-space(@class),' '),' unlogged ') and contains(concat(' ',normalize-space(@class),' '),' logbox ')])"
+const XPATH_to_get_notif_block = "//div[contains(concat(' ',normalize-space(@class),' '),' notifs-links ')]/div"
+const XPATH_to_count_alert     = "count(.//ul/li[not(contains(concat(' ', normalize-space(@class), ' '), ' dropdown-empty-message '))])"
+
+let state = 0;
+
+const connection = document.evaluate( XPATH_to_test_connection, document, null, XPathResult.ANY_TYPE, null );
+
+if( connection.numberValue == 0) { // Logged
+  state = 1;
+  const notifLinks = document.evaluate( XPATH_to_get_notif_block, document, null, XPathResult.ANY_TYPE, null );
+
+  const pmDOM  = (notifLinks.iterateNext());
+  const notifDOM = (notifLinks.iterateNext());
+  const alertDOM = (notifLinks.iterateNext());
+
+  const countPM = document.evaluate( XPATH_to_count_alert , pmDOM, null, XPathResult.ANY_TYPE, null );
+  const countNotif = document.evaluate( XPATH_to_count_alert, notifDOM, null, XPathResult.ANY_TYPE, null );
+
+  if( countPM.numberValue + countNotif.numberValue > 0 ) { // 1 notif or more
+    state = 2;
+  }
+}
+
+// Send the state to background script
+var sending = browser.runtime.sendMessage({ state: state });
+sending.then(null, null);


### PR DESCRIPTION
Bonjour,

Le but c'est de vérifier l'état chargée.  Si on visite le site et que l'état n'est pas le même que celui de l’icône, alors on fait une mise-à-jour.

Ça améliore la réactivité. Quand on se connecte ou se déconnecte l’icône de Clem change instantanément. Si on visite le site avec une notification alors que la barre ne l'indique pas, l’icône se met à jour et vice versa.

C'était un comportement assez déroutant. On lit l'ensemble des notifications et l'extension nous indiquait qu'il en restait encore. Il manque certainement un coup de linter.

Bonne journée. \o